### PR TITLE
IQA-111: Move api-routing-configuration to api-rootfolder and cleanup app-context

### DIFF
--- a/web-app/src/__init__.py
+++ b/web-app/src/__init__.py
@@ -30,10 +30,9 @@ def create_app():
     with app.app_context():
         from .services.UserService import UserService
 
-        from .template_extensions import error_handlers
-        from .template_extensions import context_preprocessors
+        from .template_extensions import error_handlers, context_preprocessors
 
-        from .api.v1 import api_routing_configuration
+        from .api import api_routing_configuration
 
         from .modules import routing_configuration
 

--- a/web-app/src/api/api_routing_configuration.py
+++ b/web-app/src/api/api_routing_configuration.py
@@ -1,8 +1,6 @@
 from flask import current_app as app
 
 
-from . import admin
+from .v1 import admin, subjects
 app.register_blueprint(admin.api_v1__admin_controller)
-
-from . import subjects
 app.register_blueprint(subjects.api_v1__subjects_controller)

--- a/web-app/src/api/v1/admin.py
+++ b/web-app/src/api/v1/admin.py
@@ -1,7 +1,7 @@
 from flask import current_app as app
 from flask import Blueprint, jsonify, request
 from flask_migrate import upgrade
-
+from os import path
 
 
 api_v1__admin_controller = Blueprint(
@@ -20,3 +20,19 @@ def run_migrations():
         return jsonify({ 'status': 'success' }), 200
 
     return jsonify({ 'status': 'denied' }), 403
+
+
+@api_v1__admin_controller.route('/app-version', methods=['GET'])
+def get_appversion():
+
+    version_number = '0.0.0'
+
+    version_file_path = path.join(app.root_path, '../version.txt')
+
+    try:
+        with app.open_resource(version_file_path, 'r') as version_file:
+            version_number = version_file.read()
+    except FileNotFoundError:
+        print(version_file_path + ' does not exist')
+
+    return jsonify({ 'version': version_number })

--- a/web-app/src/api/v1/admin.py
+++ b/web-app/src/api/v1/admin.py
@@ -7,11 +7,11 @@ from flask_migrate import upgrade
 api_v1__admin_controller = Blueprint(
     'api_v1__admin_controller',
     __name__,
-    url_prefix='/api/v1/admin/'
+    url_prefix='/api/v1/admin'
 )
 
 
-@api_v1__admin_controller.route('run-migrations', methods=['GET'])
+@api_v1__admin_controller.route('/run-migrations', methods=['GET'])
 def run_migrations():
 
     if request.args.get('migrationkey') == app.config['MIGRATION_KEY']:

--- a/web-app/src/api/v1/subjects.py
+++ b/web-app/src/api/v1/subjects.py
@@ -7,11 +7,11 @@ from ...repositories.SubjectRepository import SubjectRepository
 api_v1__subjects_controller = Blueprint(
     'api_v1__subjects_controller',
     __name__,
-    url_prefix='/api/v1/subjects/'
+    url_prefix='/api/v1/subjects'
 )
 
 
-@api_v1__subjects_controller.route('', methods=['GET'])
+@api_v1__subjects_controller.route('/', methods=['GET'])
 def get_all():
 
     all_subjects = SubjectRepository.get_all()


### PR DESCRIPTION
Anpassen der Registrierung der API-Controller.
Somit können wir die API-Routes für unterschiedliche versionen, pro Controller registrieren.